### PR TITLE
Ignore 3D textures in materials when in face select mode

### DIFF
--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -1345,6 +1345,11 @@ namespace Sabresaurus.SabreCSG
                             string assetPath = AssetDatabase.GetAssetPath(newTexture);
                             TextureImporter importer = TextureImporter.GetAtPath(assetPath) as TextureImporter;
 
+                            if (importer == null)
+                            {
+                                continue;
+                            }
+
 #if UNITY_5_5_OR_NEWER
                             // Unity 5.5 refactored the TextureImporter, requiring slightly different logic
                             TextureImporterSettings importerSettings = new TextureImporterSettings();


### PR DESCRIPTION
Add dropout if the texture importer doesn't exist for a texture in a material for a selected face in face select mode.
3D textures do not have TextureImporter importers so the cast result is null, which caused endless errors and stopped the UIs from showing anything until this fix was implemented.